### PR TITLE
`getAlbumBrowseId()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ npm i youtube-moosick
 * [`getAlbum`](#getalbum)
 * [`getArtist`](#getartist)
 * [`getPlaylist`](#getplaylist)
+* [`getAlbumBrowseId`](#getalbumbrowseid)
 
 ### `search`
 
@@ -388,6 +389,32 @@ GtnRURDTTBH',
   }
 }
  */
+```
+
+### getAlbumBrowseId
+
+▸ **getAlbumBrowseId**(`listID`): `Promise`<`string`\>
+
+Gets the `browseId` for the album based on the newer `listID`
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `listID` | `string` | The `listID` of the album |
+
+#### Returns
+
+`Promise`<`string`\>
+
+String The `browseID` of the album
+
+Example:
+```typescript
+const api = await MooSick.new();
+const results = await api.getAlbumBrowseId('OLAK5uy_ljhFMBuzqiynvNq_3dC2QhQaz12zkD0LE');
+
+console.log(results);
 ```
 
 ## Tests

--- a/src/YoutubeMoosick.ts
+++ b/src/YoutubeMoosick.ts
@@ -388,6 +388,20 @@ export class YoutubeMoosick extends AsyncConstructor {
 		return GetArtistParser.parseArtistURLPage(ctx as ArtistURLFullResult);
 	}
 
+	/**
+	 * Gets the `browseId` for the album based on the newer `listID`
+	 * @param listID - The `listID` of the album
+	 * @returns String The `browseID` of the album
+	 *
+	 * Example:
+	 * ```typescript
+	 * const api = await MooSick.new();
+	 * const results = await api.getAlbumBrowseId('OLAK5uy_ljhFMBuzqiynvNq_3dC2QhQaz12zkD0LE');
+	 *
+	 * console.log(results);
+	 * ```
+	 *
+	 */
 	public async getAlbumBrowseId(listID: string): Promise<string> {
 		if (!listID.startsWith('OLAK')) {
 			throw new IllegalArgumentError('Artist browse IDs must start with "OLAK"', 'listID');

--- a/src/YoutubeMoosick.ts
+++ b/src/YoutubeMoosick.ts
@@ -15,11 +15,8 @@ import type { Result as IResult } from './resources/etc/rawResultTypes/common.js
 import type { YtCfgMain } from './resources/etc/cfgInterface.js';
 import {
 	AlbumURL,
-	PlaylistURL,
 	ArtistURL,
-	SearchSuggestions,
-	PlaylistContent,
-	ContinuablePlaylistURL,
+	ContinuablePlaylistURL, PlaylistContent, PlaylistURL, SearchSuggestions,
 } from './resources/resultTypes/index.js';
 import {
 	Song,
@@ -27,11 +24,9 @@ import {
 	Video,
 	Artist,
 	ArtistExtended,
-	ContinuableUnsorted,
-	Album,
 	ContinuableResult,
 	ContinuableResultBlueprint,
-	ContinuableResultFactory,
+	ContinuableResultFactory, ContinuableUnsorted, Album,
 } from './resources/generalTypes/index.js';
 
 export * from './resources/resultTypes/index.js';
@@ -392,5 +387,22 @@ export class YoutubeMoosick extends AsyncConstructor {
 
 		return GetArtistParser.parseArtistURLPage(ctx as ArtistURLFullResult);
 	}
-}
 
+	public async getAlbumBrowseId(listID: string): Promise<string> {
+		const res = await this.client.get(
+			`https://music.youtube.com/playlist?${
+				new URLSearchParams({
+					list: listID,
+				}).toString()
+			}`,
+			{},
+		);
+
+		const result = /"MPREb.+?"/g.exec(res.data) ?? [];
+		if (result.length > 0) {
+			return decodeURI(encodeURI(result[0])).replaceAll('"', '').replaceAll('\\', '');
+		}
+
+		throw new IllegalStateError('No Album ID was found');
+	}
+}

--- a/src/YoutubeMoosick.ts
+++ b/src/YoutubeMoosick.ts
@@ -389,6 +389,10 @@ export class YoutubeMoosick extends AsyncConstructor {
 	}
 
 	public async getAlbumBrowseId(listID: string): Promise<string> {
+		if (!listID.startsWith('OLAK')) {
+			throw new IllegalArgumentError('Artist browse IDs must start with "OLAK"', 'listID');
+		}
+
 		const res = await this.client.get(
 			`https://music.youtube.com/playlist?${
 				new URLSearchParams({

--- a/src/test/tests/apiAllTest.ts
+++ b/src/test/tests/apiAllTest.ts
@@ -578,3 +578,10 @@ test('api_getArtistURLParser', async (t) => {
 
 	t.end();
 });
+
+test('api_album_converter', async (t) => {
+	const ytms = await YoutubeMoosick.new();
+	const albumBrowseID = await ytms.getAlbumBrowseId('OLAK5uy_n3ccnwJfIE9hA5_SfbjIRpvpkEF5S5Al8');
+	console.log(albumBrowseID);
+	t.true(albumBrowseID === 'MPREb_l7KWNUEzx39');
+});

--- a/src/test/tests/apiAllTest.ts
+++ b/src/test/tests/apiAllTest.ts
@@ -581,7 +581,6 @@ test('api_getArtistURLParser', async (t) => {
 
 test('api_album_converter', async (t) => {
 	const ytms = await YoutubeMoosick.new();
-	const albumBrowseID = await ytms.getAlbumBrowseId('OLAK5uy_n3ccnwJfIE9hA5_SfbjIRpvpkEF5S5Al8');
-	console.log(albumBrowseID);
+	const albumBrowseID = await ytms.getAlbumBrowseId('OLAK5uy_ljhFMBuzqiynvNq_3dC2QhQaz12zkD0LE');
 	t.true(albumBrowseID === 'MPREb_l7KWNUEzx39');
 });


### PR DESCRIPTION
This PR attempts to resolve #162 , where YouTube defaults to the new OLAK format for its ID for albums.

### `getAlbumBrowseId()`
This converts this
`https://music.youtube.com/playlist?list=OLAK5uy_ljhFMBuzqiynvNq_3dC2QhQaz12zkD0LE`
to
`MPREb_l7KWNUEzx39`

### Test `api_album_converter`
Tests to validate the `getAlbumBrowseId()` function